### PR TITLE
Don't abort build on lint error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
I'm getting errors when running `gradle assembleRelease`:
```
> Task :app:lintVitalRelease
/home/pierre/www/PixelArtist/app/src/main/res/values/strings.xml:33: Error: "drawer_open" is not translated in "es" (Spanish), "pt" (Portuguese) [MissingTranslation]
    <string name="drawer_open">Open navigation drawer</string>
            ~~~~~~~~~~~~~~~~~~
/home/pierre/www/PixelArtist/app/src/main/res/values/strings.xml:34: Error: "drawer_close" is not translated in "es" (Spanish), "pt" (Portuguese) [MissingTranslation]
    <string name="drawer_close">Close navigation drawer</string>
            ~~~~~~~~~~~~~~~~~~~
```

This patch makes the build continue even if it finds lint errors.